### PR TITLE
WIP: variables to control image name and source

### DIFF
--- a/ubuntu-14.04-amd64.json
+++ b/ubuntu-14.04-amd64.json
@@ -29,10 +29,10 @@
       "disk_size": 20480,
       "guest_os_type": "ubuntu-64",
       "http_directory": "http",
-      "iso_checksum": "8acd2f56bfcba2f7ac74a7e4a5e565ce68c024c38525c0285573e41c86ae90c0",
-      "iso_checksum_type": "sha256",
-      "iso_url": "{{user `mirror`}}/14.04.2/ubuntu-14.04.2-server-amd64.iso",
-      "output_directory": "builds/chef-ubuntu-14.04-amd64-vmware",
+      "iso_checksum": "{{ user `iso_checksum` }}",
+      "iso_checksum_type": "{{ user `iso_checksum_type` }}",
+      "iso_url": "{{ user `iso_url` }}",
+      "output_directory": "builds/{{ user `name` }}-vmware",
       "shutdown_command": "echo 'opsadmin'|sudo -S shutdown -P now",
       "ssh_password": "opsadmin",
       "ssh_port": 22,
@@ -40,7 +40,7 @@
       "ssh_wait_timeout": "10000s",
       "tools_upload_flavor": "linux",
       "type": "vmware-iso",
-      "vm_name": "packer-ubuntu-14.04-amd64",
+      "vm_name": "packer-{{ user `name` }}",
       "vmx_data": {
         "cpuid.coresPerSocket": "1",
         "memsize": "1024",
@@ -79,13 +79,11 @@
   ],
   "variables": {
     "arch": "64",
-    "box_basename": "ubuntu-14.04",
+    "box_basename": "ubuntu-14.04.4",
     "build_timestamp": "{{isotime \"20060102150405\"}}",
     "git_revision": "__unknown_git_revision__",
     "metadata": "floppy/dummy_metadata.json",
     "mirror": "http://releases.ubuntu.com",
-    "name": "ubuntu-14.04",
-    "template": "ubuntu-14.04-amd64",
     "version": "0.1"
   }
 }


### PR DESCRIPTION
Opening this PR for feedback to see if this is a good place to commit some changes. I'm interested in being able to do the following:
- Modify the `iso_url` to allow `file://` loads
- Allow for different checksums (the `.iso` which is linked has moved to an archive mirror)
- Allow for the modification of the VM name

```
packer build \
  -var 'ssh_pub_key=/path/to/ssh_key.pub' \
  -var 'iso_url=ubuntu-14.04.4-server-amd64.iso' \
  -var 'iso_checksum=2ac1f3e0de626e54d05065d6f549fa3a' \
  -var 'iso_checksum_type=md5' \
  -var 'name=ubuntu-14.04.4-server-amd64' \
  ubuntu-14.04.4-amd64.json
```

What are your thoughts on these modifications to the Packer template? Is there an alternative change you would prefer?
